### PR TITLE
Fix crash in Com_Error when com_noErrorInterrupt is nullptr

### DIFF
--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -237,7 +237,7 @@ void QDECL Com_Error( int code, const char *fmt, ... ) {
 
 #if defined(_WIN32) && defined(_DEBUG)
 	if ( code != ERR_DISCONNECT && code != ERR_NEED_CD ) {
-		if (!com_noErrorInterrupt->integer) {
+		if (com_noErrorInterrupt != NULL && !com_noErrorInterrupt->integer) {
 			__asm {
 				int 0x03
 			}


### PR DESCRIPTION
Problem:
A crash occurs in Win32 Debug builds when Com_Error is called before the com_noErrorInterrupt cvar is initialized. This can happen during early initialization errors, such as running the game without the required .pak files, causing the pointer to be nullptr and leading to a segmentation fault when accessed.

Solution:
Added a simple null check (com_noErrorInterrupt != NULL) before dereferencing the pointer in the debug-specific code block. This change preserves the original debug logic (the intentional breakpoint) while preventing a hard crash when the cvar is not yet available.

Important:
This fix only affects Win32 Debug builds (guarded by #if defined(_WIN32) && defined(_DEBUG)) and has zero impact on release builds or other platforms. The debug functionality remains fully intact when the cvar is properly initialized.

Root Cause:
The Com_Error function can be called during initial filesystem initialization (e.g., when no game data is found). Since com_noErrorInterrupt is initialized later as a cvar, its pointer is null at this early stage, causing a crash when the debug code attempts to check its value.